### PR TITLE
Allow READ_WRITE | OPEN

### DIFF
--- a/src/drivers/Sqlite3Driver.js
+++ b/src/drivers/Sqlite3Driver.js
@@ -51,7 +51,6 @@ class Sqlite3Driver {
     this.#getNewConnection = () => new Promise((resolve, reject) => {
       const newConnection = new sqlite3.Database(
         driverConfig.filePath,
-        sqlite3.OPEN_READWRITE,
         (error) => {
           if (!error) {
             resolve(newConnection);


### PR DESCRIPTION
Remove sqlite3.OPEN_READWRITE

leave default node-sqlite3 config

- The default value is OPEN_READWRITE | OPEN_CREATE.

Create DB if doesn't exist, or OPEN_READWRITE 

ultimately, should add driverConfig.mode